### PR TITLE
feat: add markdown source preview

### DIFF
--- a/libraries/github-file.ts
+++ b/libraries/github-file.ts
@@ -378,7 +378,7 @@ export abstract class ExtendFilePreview {
     const filePath = getRepoPath().replace("blob/", "");
     if (!this.isSupportedFile(filePath)) return;
     const frameElem = await this.addFrameToFileBody(
-      selectOrThrow(".Box.mt-3>.Box-body.blob-wrapper"),
+      selectOrThrow(".Box.mt-3>.Box-body"),
       filePath,
       false
     );

--- a/libraries/github-file.ts
+++ b/libraries/github-file.ts
@@ -196,14 +196,14 @@ export abstract class ExtendFilePreview {
             class: "octicon octicon-code",
             height: 16,
             version: "1.1",
-            viewBox: "0 0 14 16",
-            width: 14,
+            viewBox: "0 0 16 16",
+            width: 16,
           },
           children: [
             {
               attributes: {
                 d:
-                  "M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z",
+                  "M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z",
                 "fill-rule": "evenodd",
               },
               tagName: "path",
@@ -240,14 +240,13 @@ export abstract class ExtendFilePreview {
             class: "octicon octicon-file",
             height: 16,
             version: "1.1",
-            viewBox: "0 0 12 16",
-            width: 12,
+            viewBox: "0 0 16 16",
+            width: 16,
           },
           children: [
             {
               attributes: {
-                d: `M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45
-                1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z`,
+                d: `M3.75 1.5a.25.25 0 00-.25.25v11.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.25V1.75z`,
                 "fill-rule": "evenodd",
               },
               tagName: "path",

--- a/libraries/github-file.ts
+++ b/libraries/github-file.ts
@@ -134,6 +134,7 @@ export abstract class ExtendFilePreview {
       const height = `${scrollHeight}px`;
       frameParent.style.height = height;
       frameParent.style.maxHeight = height;
+      frameParent.scrollLeft = 0;
       return this.selectButton(button);
     };
   }

--- a/libraries/request.ts
+++ b/libraries/request.ts
@@ -1,6 +1,6 @@
 export function request(
   url: RequestInfo,
-  options?: RequestInit
+  options?: RequestInit & { data?: string }
 ): Promise<Partial<Response>> {
   if (!window.GM_xmlhttpRequest) return fetch(url, options);
   return new Promise((resolve, reject) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6595,11 +6595,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
-      "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw=="
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6595,6 +6595,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
+      "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw=="
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     }
   },
   "dependencies": {
-    "cheerio": "git+http://github.com/iamogbz/cheerio-web.git",
-    "highlight.js": "^10.3.2"
+    "cheerio": "git+http://github.com/iamogbz/cheerio-web.git"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "lint": "eslint .",
     "release": "semantic-release",
     "server": "http-server ./dist",
-    "start": "nodemon -x 'npm run build && npm run server'",
+    "start": "env NODE_ENV=development nodemon -x 'npm run build && npm run server'",
     "test": "tsc --noEmit && jest"
   },
   "version": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     }
   },
   "dependencies": {
-    "cheerio": "git+http://github.com/iamogbz/cheerio-web.git"
+    "cheerio": "git+http://github.com/iamogbz/cheerio-web.git",
+    "highlight.js": "^10.3.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/scripts/github-file-preview-apib/README.md
+++ b/scripts/github-file-preview-apib/README.md
@@ -1,4 +1,4 @@
-# Github File Preview APIB
+# GitHub File Preview APIB
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-apib.user.js)
 

--- a/scripts/github-file-preview-html/README.md
+++ b/scripts/github-file-preview-html/README.md
@@ -1,4 +1,4 @@
-# Github File Preview HTML
+# GitHub File Preview HTML
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-html.user.js)
 

--- a/scripts/github-file-preview-html/index.user.ts
+++ b/scripts/github-file-preview-html/index.user.ts
@@ -18,6 +18,11 @@ class ExtendFilePreviewHTML extends ExtendFilePreview {
       load: this.getFileContent.bind(this),
     });
   }
+
+  getScrollHeight(frameElem: HTMLIFrameElement) {
+    if (!frameElem.contentWindow) return 0;
+    return frameElem.contentWindow.document.body.scrollHeight + 1;
+  }
 }
 
 (function () {

--- a/scripts/github-file-preview-md/README.md
+++ b/scripts/github-file-preview-md/README.md
@@ -2,4 +2,4 @@
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-md.user.js)
 
-![extend-file-preview-md-demo](https://github.com/iamogbz/oh-my-scripts/raw/master/src/assets/images/extend-file-preview-md-demo.gif)
+![extend-file-preview-md-demo](https://user-images.githubusercontent.com/2528959/99179811-fdf9a380-26ee-11eb-97fe-8e3da9f0b22c.gif)

--- a/scripts/github-file-preview-md/README.md
+++ b/scripts/github-file-preview-md/README.md
@@ -1,4 +1,4 @@
-# Github File Preview Markdown
+# GitHub File Preview Markdown
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-md.user.js)
 

--- a/scripts/github-file-preview-md/README.md
+++ b/scripts/github-file-preview-md/README.md
@@ -1,0 +1,5 @@
+# Github File Preview Markdown
+
+[Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-md.user.js)
+
+![extend-file-preview-md-demo](https://github.com/iamogbz/oh-my-scripts/raw/master/src/assets/images/extend-file-preview-md-demo.gif)

--- a/scripts/github-file-preview-md/header.json
+++ b/scripts/github-file-preview-md/header.json
@@ -1,6 +1,6 @@
 {
-    "description": "Render the raw markdown in thub",
-    "grant": ["GM_xmlhttpRequest"],
-    "include": ["*://github.com/*"],
-    "name": "GitHub File Preview Markdown"
-  }
+  "description": "Render the raw markdown in thub",
+  "grant": ["GM_xmlhttpRequest"],
+  "include": ["*://github.com/*"],
+  "name": "GitHub File Preview Markdown"
+}

--- a/scripts/github-file-preview-md/header.json
+++ b/scripts/github-file-preview-md/header.json
@@ -1,0 +1,6 @@
+{
+    "description": "Render the raw markdown in thub",
+    "grant": ["GM_xmlhttpRequest"],
+    "include": ["*://github.com/*"],
+    "name": "GitHub File Preview Markdown"
+  }

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -1,6 +1,7 @@
-import hljs from "highlight.js/lib/core";
-import markdown from "highlight.js/lib/languages/markdown";
+import * as hljs from "highlight.js/lib/core";
+import * as markdown from "highlight.js/lib/languages/markdown";
 
+import { selectDOM } from "libraries/dom";
 import { ExtendFilePreview, filePreviewNS } from "libraries/github-file";
 
 class ExtendFilePreviewMD extends ExtendFilePreview {
@@ -14,10 +15,30 @@ class ExtendFilePreviewMD extends ExtendFilePreview {
   async prepareHTML(fileContent: string) {
     return hljs.highlight("md", fileContent).value;
   }
+
+  // swap source and rendered since github renders markdown by default
+  showSource(frameElem: HTMLIFrameElement) {
+    return super.showRendered(frameElem);
+  }
+
+  showRendered(frameElem: HTMLIFrameElement) {
+    return super.showSource(frameElem);
+  }
+
+  addButtonsToFileHeaderActions(
+    actionsElem: HTMLElement,
+    frameElem: HTMLIFrameElement
+  ) {
+    super.addButtonsToFileHeaderActions(actionsElem, frameElem);
+    selectDOM<HTMLButtonElement>(
+      `.btn.BtnGroup-item[data-toggle-action="${this.toggleActionRender}"]`
+    )?.click();
+  }
 }
 
 (function () {
   "use strict";
+  // @ts-expect-error highlight library type errors https://github.com/highlightjs/highlight.js/issues/2682
   hljs.registerLanguage("md", markdown);
   new ExtendFilePreviewMD().setup();
 })();

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -1,7 +1,5 @@
-// import * as hljs from "highlight.js/lib/core";
-// import * as markdown from "highlight.js/lib/languages/markdown";
-
 import { selectDOM } from "libraries/dom";
+import { isSingleFile, onAjaxedPagesRaw } from "libraries/github";
 import { ExtendFilePreview, filePreviewNS } from "libraries/github-file";
 import { request } from "libraries/request";
 
@@ -60,12 +58,16 @@ class ExtendFilePreviewMD extends ExtendFilePreview {
       `.btn.BtnGroup-item[data-toggle-action="${this.toggleActionRender}"]`
     )?.click();
   }
+
+  setup() {
+    onAjaxedPagesRaw(() => {
+      if (!isSingleFile()) return;
+      this.initFeature();
+    });
+  }
 }
 
 (function () {
   "use strict";
-  // hljs.registerLanguage("md", markdown);
-  // const highlightCSS = GM_getResourceText("HIGHLIGHT_CSS");
-  // GM_addStyle(highlightCSS);
   new ExtendFilePreviewMD().setup();
 })();

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -1,0 +1,30 @@
+import { ExtendFilePreview, filePreviewNS } from "libraries/github-file";
+import { request } from "libraries/request";
+
+class ExtendFilePreviewMD extends ExtendFilePreview {
+  constructor() {
+    super();
+    this.id = filePreviewNS`extend-md`;
+    this.fileTypes = new Set(["md"]);
+    this.featureClass = filePreviewNS`extend-md`;
+  }
+
+  prepareHTML(fileContent: string) {
+    const host = "https://d31myey2oeipxs.cloudfront.net/v1";
+    const apib = btoa(fileContent);
+    return request(host, { headers: { "X-Blueprint": apib } })
+      .then((r) => r.text?.())
+      .then((renderedHtml) => {
+        return renderedHtml
+          ?.replace(/<a/g, `<a target="_blank"`)
+          .replace(/href="#/g, `style="cursor:default" no-href="#`)
+          .replace(".collapse-button{", ".collapse-button{display:none;")
+          .replace(".collapse-content{max-height:0;", ".collapse-content{");
+      });
+  }
+}
+
+(function () {
+  "use strict";
+  new ExtendFilePreviewMD().setup();
+})();

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -1,5 +1,7 @@
+import hljs from "highlight.js/lib/core";
+import markdown from "highlight.js/lib/languages/markdown";
+
 import { ExtendFilePreview, filePreviewNS } from "libraries/github-file";
-import { request } from "libraries/request";
 
 class ExtendFilePreviewMD extends ExtendFilePreview {
   constructor() {
@@ -9,22 +11,13 @@ class ExtendFilePreviewMD extends ExtendFilePreview {
     this.featureClass = filePreviewNS`extend-md`;
   }
 
-  prepareHTML(fileContent: string) {
-    const host = "https://d31myey2oeipxs.cloudfront.net/v1";
-    const apib = btoa(fileContent);
-    return request(host, { headers: { "X-Blueprint": apib } })
-      .then((r) => r.text?.())
-      .then((renderedHtml) => {
-        return renderedHtml
-          ?.replace(/<a/g, `<a target="_blank"`)
-          .replace(/href="#/g, `style="cursor:default" no-href="#`)
-          .replace(".collapse-button{", ".collapse-button{display:none;")
-          .replace(".collapse-content{max-height:0;", ".collapse-content{");
-      });
+  async prepareHTML(fileContent: string) {
+    return hljs.highlight("md", fileContent).value;
   }
 }
 
 (function () {
   "use strict";
+  hljs.registerLanguage("md", markdown);
   new ExtendFilePreviewMD().setup();
 })();

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -21,12 +21,33 @@ class ExtendFilePreviewMD extends ExtendFilePreview {
     })
       .then((r) => r.text?.())
       .then((renderedHtml) => {
-        return renderedHtml
-          ?.replace(/<a/g, `<a target="_blank"`)
-          .replace(/href="#/g, `style="cursor:default" no-href="#`)
-          .replace(".collapse-button{", ".collapse-button{display:none;")
-          .replace(".collapse-content{max-height:0;", ".collapse-content{");
+        if (!renderedHtml) return "";
+        const lineNumber = (n: number) =>
+          `<span class="blob-num bg-gray-light js-line-number" style="display: inline-block; margin-right: 10px">${n}</span>`;
+        return this.replaceText(renderedHtml, "<pre>", "</pre>", (text) =>
+          text
+            ?.split(/\r?\n/)
+            .map((line, i) => `${lineNumber(i + 1)}${line}`)
+            .join("\n")
+        );
       });
+  }
+
+  replaceText(
+    text: string,
+    startTag: string,
+    endTag: string,
+    replaceFn: (content: string) => string
+  ): string {
+    const startIndex = text.indexOf(startTag);
+    const endIndex = text.lastIndexOf(endTag);
+    return (
+      text.substring(0, startIndex) +
+      startTag +
+      replaceFn(text.substring(startIndex + startTag.length, endIndex)) +
+      endTag +
+      text.substring(endIndex + endTag.length)
+    );
   }
 
   frameElement(attrs: Record<string, string | undefined>) {

--- a/scripts/github-pr-file-filters/README.md
+++ b/scripts/github-pr-file-filters/README.md
@@ -1,4 +1,4 @@
-# Github PR File Filters
+# GitHub PR File Filters
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-pr-file-filters.user.js)
 

--- a/typings/highlight.js.d.ts
+++ b/typings/highlight.js.d.ts
@@ -1,0 +1,1 @@
+import "highlight.js";

--- a/typings/monkey.d.ts
+++ b/typings/monkey.d.ts
@@ -1,4 +1,8 @@
 // https://openuserjs.org/libs/Marti/GM_setStyle
 declare function GM_setStyle(params: { data: string }): void;
+// https://www.tampermonkey.net/documentation.php#GM_addStyle
+declare function GM_addStyle(css: string): void;
+// https://www.tampermonkey.net/documentation.php#GM_getResourceText
+declare function GM_getResourceText(name: string): string;
 // https://www.tampermonkey.net/documentation.php#GM_xmlhttpRequest
 declare function GM_xmlhttpRequest(details: Record<string, unknown>): void;

--- a/webpack/utils.ts
+++ b/webpack/utils.ts
@@ -36,7 +36,7 @@ export function getCompileEntries() {
 
 export function getConfig(diff: Partial<Configuration>) {
   return {
-    mode: isProdMode() ? NodeEnv.PRODUCTION : NodeEnv.DEVELOPMENT,
+    mode: NodeEnv.PRODUCTION,
     ...diff,
   };
 }


### PR DESCRIPTION
# Description

Rendes github flavoured markdown using the [api](https://docs.github.com/en/free-pro-team@latest/rest/reference/markdown)

![Screen Recording 2020-11-15 at 2 57 57 AM](https://user-images.githubusercontent.com/2528959/99179811-fdf9a380-26ee-11eb-97fe-8e3da9f0b22c.gif)

## Checklist

- [x] This PR has updated documentation
- [ ] This PR has sufficient testing

### Comments

- N/A
