### PR TITLE
fix(github-file-preview-md): fails on repo readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ Available on:
   http://127.0.0.1:8080
 ```
 
+> Default localhost can be overridden by using the `DEV_SERVER` environment variable to provide an authority url without the trailing slash e.g. `DEV_SERVER='https://my.server.dev:9090' npm start`
+
 * Access the server at <http://localhost:8080> and click on any script to install it. You need an extension in your browser to auto install and pull updates to the script, see [what to know before starting](#what-should-i-know-before-i-get-started)
 
 * Make changes, wait for build and refresh your browser to pull the new changes. You might need to configure your user script to always refresh and not use a cache

--- a/libraries/github-file.ts
+++ b/libraries/github-file.ts
@@ -380,7 +380,7 @@ export abstract class ExtendFilePreview {
   }
 
   async initSingleFile() {
-    const fileHeaderElem = selectOrThrow(".Box.mt-3>.Box-header.py-2");
+    const fileHeaderElem = selectOrThrow(".Box-header.js-blob-header");
     const filePath = getRepoPath().replace("blob/", "");
     if (!this.isSupportedFile(filePath)) return;
     const frameElem = await this.addFrameToFileBody(

--- a/scripts/github-file-preview-md/README.md
+++ b/scripts/github-file-preview-md/README.md
@@ -1,6 +1,6 @@
 # GitHub File Preview Markdown
 
-GitHub now supports this natively; albiet with a page refresh. If you still want to use this instead, see below.
+> __GitHub now supports this natively. If you still want to use this instead, maybe to avoid the page refresh in the native implementation, see below.__
 
 [Install](https://github.com/iamogbz/oh-my-scripts/raw/master/dist/github-file-preview-md.user.js)
 

--- a/scripts/github-file-preview-md/index.user.ts
+++ b/scripts/github-file-preview-md/index.user.ts
@@ -1,4 +1,4 @@
-import { selectDOM } from "libraries/dom";
+import { selectAll, selectDOM } from "libraries/dom";
 import { isSingleFile } from "libraries/github";
 import { ExtendFilePreview, filePreviewNS } from "libraries/github-file";
 import { request } from "libraries/request";
@@ -112,10 +112,21 @@ class ExtendFilePreviewMD extends ExtendFilePreview {
     actionsElem: HTMLElement,
     frameElem: HTMLIFrameElement
   ) {
+    this.hideNativeButtons(actionsElem);
     super.addButtonsToFileHeaderActions(actionsElem, frameElem);
     selectDOM<HTMLButtonElement>(
       `.btn.BtnGroup-item[data-toggle-action="${this.toggleActionRender}"]`
     )?.click();
+  }
+
+  hideNativeButtons(baseElement: HTMLElement) {
+    const nativeActionBtn = (s: string) => `.BtnGroup>a.${s}[href*=".md"]`;
+    const nativeActionBtns = ["source", "rendered"]
+      .map(nativeActionBtn)
+      .join(",");
+    selectAll<HTMLAnchorElement>(nativeActionBtns, baseElement).map(
+      (a) => (a.style.display = "none")
+    );
   }
 
   initCondition() {

--- a/webpack/configs/package.ts
+++ b/webpack/configs/package.ts
@@ -84,11 +84,11 @@ export default [
             const gitCommitHash = getGitCommitHash().substr(0, 7);
             const uriBase = isProdMode()
               ? `${data.homepage}/raw/${gitCommitHash}/dist`
-              : "http://localhost:8080";
+              : process.env.DEV_SERVER || "http://localhost:8080";
             // Append each path with a resource key to override cache for local dev
             const urlSuffix = isProdMode()
               ? ""
-              : `v=${Math.random().toString(36).substring(7)}`;
+              : `?v=${Math.random().toString(36).substring(7)}`;
             const uri = (path: string) => `${uriBase}/${path}${urlSuffix}`;
 
             // Plugin will emit the file ending with .user.js


### PR DESCRIPTION
# Description

Fixes #278

- Hide native markdown render buttons when enabled
- Fix append query param to built dev host urls
- Allow overriding development server url for built user scripts

## Checklist

- [x] This PR has updated documentation
- [ ] This PR has sufficient testing

### Comments

N/A
