### PR TITLE
fix(export-element): fallback to export as image when window open is not supported

### DIFF
--- a/scripts/export-element/index.user.ts
+++ b/scripts/export-element/index.user.ts
@@ -23,6 +23,19 @@ import { html2canvas } from "libraries/html2canvas";
   };
 
   /**
+   * Create keyboard event handler that triggers callback only on specific key
+   * TODO: Handle multiple keys and combinations
+   * TODO: options to prevent default event action and stop propagation
+   */
+  function onKey(params: { key: string; callback: () => void }) {
+    return (event: KeyboardEvent) => {
+      if (event.key === params.key) {
+        params.callback();
+      }
+    };
+  }
+
+  /**
    * Find the uppermost node that satisfies the predicate
    */
   function findLastNodeWithPredicate(
@@ -277,11 +290,19 @@ import { html2canvas } from "libraries/html2canvas";
       e.stopPropagation();
       // TODO: check if download is permitted by browser
     });
-    // close modal when clicking outside the link
-    modalWrapper.addEventListener("click", () => {
+    const closePreview = () => {
       modalWrapper.remove();
       URL.revokeObjectURL(dataURI); // free up memory
+      document.removeEventListener("keydown", closePreviewOnEscape);
+    };
+    const closePreviewOnEscape = onKey({
+      key: "Escape",
+      callback: closePreview,
     });
+    // close modal when clicking outside the link
+    modalWrapper.addEventListener("click", closePreview);
+    // close modal when pressing escape
+    document.addEventListener("keydown", closePreviewOnEscape);
   }
 
   /**

--- a/scripts/export-element/index.user.ts
+++ b/scripts/export-element/index.user.ts
@@ -75,13 +75,6 @@ import { html2canvas } from "libraries/html2canvas";
         return containsAll(nodeText, params.matchWords);
       },
     );
-
-    console.log(
-      (event.target as Node).textContent,
-      // @ts-expect-error IE before version 9
-      document.selection?.createRange?.().text,
-      params.target,
-    );
   }
   document.addEventListener("contextmenu", handleUpdateTarget);
   document.addEventListener("mouseup", handleUpdateTarget);
@@ -171,7 +164,15 @@ import { html2canvas } from "libraries/html2canvas";
       "width=800,height=600",
     );
     if (!newWindow) {
-      alert("Please allow popups for this site and try again.");
+      const errorMessage =
+        "Failed to open new window. Please allow popups for this site and try again.";
+      const isInIframe = window.self !== window.top;
+      if (isInIframe) {
+        console.error(errorMessage);
+        console.error("Falling back to exporting as image.");
+        cloneAndDownloadImage(node);
+      }
+      alert(errorMessage);
       return;
     }
     const newDocument = newWindow.document;
@@ -200,14 +201,16 @@ import { html2canvas } from "libraries/html2canvas";
     const clone = cloneNodeWithStyles(window, node);
     const backgroundColor = findBackgroundColor(node);
 
-    const modalContent = document.createElement("div");
+    const modalContent = document.createElement("a");
     modalContent.style.backgroundColor = backgroundColor;
     modalContent.style.cursor = "pointer";
     modalContent.style.display = "block";
     modalContent.style.height = "fit-content";
     modalContent.style.padding = "min(1vh, 1vw)";
     modalContent.style.position = "relative";
+    modalContent.style.textDecoration = "none";
     modalContent.style.top = "1vh";
+    modalContent.style.userSelect = "none";
     modalContent.style.width = "fit-content";
 
     const modalWrapper = document.createElement("div");
@@ -264,18 +267,21 @@ import { html2canvas } from "libraries/html2canvas";
       .replace(/[/\\?%*:|"<>]+/g, filenameGlue)
       .replace(/[-]+/g, filenameGlue)}.${imageType.split("/")[1]}`;
 
-    const imageLink = document.createElement("a");
-    imageLink.target = "_blank";
-    imageLink.href = dataURI;
-    imageLink.download = filename;
+    modalContent.target = "_blank";
+    modalContent.href = dataURI;
+    modalContent.download = filename;
+    modalContent.title = `Download ${filename}`;
 
-    modalWrapper.addEventListener("click", () => modalWrapper.remove());
-    const downloadImage = (e: Event) => {
-      e.preventDefault();
+    // prevent modal from closing when clicking on the link
+    modalContent.addEventListener("click", (e) => {
       e.stopPropagation();
-      return imageLink.click();
-    };
-    modalContent.addEventListener("click", downloadImage);
+      // TODO: check if download is permitted by browser
+    });
+    // close modal when clicking outside the link
+    modalWrapper.addEventListener("click", () => {
+      modalWrapper.remove();
+      URL.revokeObjectURL(dataURI); // free up memory
+    });
   }
 
   /**


### PR DESCRIPTION
# Description

Fallback when `allow-popup`, `allow-download` is disabled on browser

- [x] Makes image download a clickable link
- [x] Clear up image memory url when modal is closed
- [ ] Add keyboard `esc` listener to dismiss capture


## Checklist

- [x] This PR has updated documentation
- [ ] This PR has sufficient testing

### Comments

N/A
